### PR TITLE
merkle Hash:: typos

### DIFF
--- a/include/nil/crypto3/zk/snark/components/merkle_tree/merkle_authentication_path_variable.hpp
+++ b/include/nil/crypto3/zk/snark/components/merkle_tree/merkle_authentication_path_variable.hpp
@@ -49,8 +49,8 @@ namespace nil {
                         merkle_authentication_path_variable(blueprint<FieldType> &bp, const std::size_t tree_depth) :
                             component<FieldType>(bp), tree_depth(tree_depth) {
                             for (std::size_t i = 0; i < tree_depth; ++i) {
-                                left_digests.emplace_back(digest_variable<FieldType>(bp, Hash::digest_bits));
-                                right_digests.emplace_back(digest_variable<FieldType>(bp, Hash::digest_bits));
+                                left_digests.emplace_back(digest_variable<FieldType>(bp, Hash::get_digest_len()));
+                                right_digests.emplace_back(digest_variable<FieldType>(bp, Hash::get_digest_len()));
                             }
                         }
 

--- a/include/nil/crypto3/zk/snark/components/merkle_tree/merkle_tree_check_read_component.hpp
+++ b/include/nil/crypto3/zk/snark/components/merkle_tree/merkle_tree_check_read_component.hpp
@@ -92,7 +92,7 @@ namespace nil {
                         const merkle_authentication_path_variable<FieldType, Hash> &path,
                         const blueprint_linear_combination<FieldType> &read_successful) :
                         component<FieldType>(bp),
-                        digest_size(Hash::digest_bits), tree_depth(tree_depth), address_bits(address_bits), leaf(leaf),
+                        digest_size(Hash::get_digest_len()), tree_depth(tree_depth), address_bits(address_bits), leaf(leaf),
                         root(root), path(path), read_successful(read_successful) {
                         /*
                            The tricky part here is ordering. For Merkle tree
@@ -131,7 +131,7 @@ namespace nil {
                         }
 
                         check_root.reset(new bit_vector_copy_component<FieldType>(
-                            bp, computed_root->bits, root.bits, read_successful, FieldType::capacity()));
+                            bp, computed_root->bits, root.bits, read_successful, FieldType::number_bits));
                     }
 
                     template<typename FieldType, typename Hash>
@@ -167,7 +167,7 @@ namespace nil {
 
                     template<typename FieldType, typename Hash>
                     std::size_t merkle_tree_check_read_component<FieldType, Hash>::root_size_in_bits() {
-                        return Hash::digest_bits;
+                        return Hash::get_digest_len();
                     }
 
                     template<typename FieldType, typename Hash>
@@ -175,10 +175,10 @@ namespace nil {
                         const std::size_t tree_depth) {
                         /* NB: this includes path constraints */
                         const std::size_t hasher_constraints = tree_depth * Hash::expected_constraints(false);
-                        const std::size_t propagator_constraints = tree_depth * Hash::digest_bits;
-                        const std::size_t authentication_path_constraints = 2 * tree_depth * Hash::digest_bits;
+                        const std::size_t propagator_constraints = tree_depth * Hash::get_digest_len();
+                        const std::size_t authentication_path_constraints = 2 * tree_depth * Hash::get_digest_len();
                         const std::size_t check_root_constraints =
-                            3 * (Hash::digest_bits + (FieldType::capacity()) - 1) / FieldType::capacity();
+                            3 * (Hash::get_digest_len() + (FieldType::capacity()) - 1) / FieldType::capacity();
 
                         return hasher_constraints + propagator_constraints + authentication_path_constraints +
                                check_root_constraints;

--- a/include/nil/crypto3/zk/snark/components/merkle_tree/merkle_tree_check_update_components.hpp
+++ b/include/nil/crypto3/zk/snark/components/merkle_tree/merkle_tree_check_update_components.hpp
@@ -91,7 +91,7 @@ namespace nil {
                             const merkle_authentication_path_variable<FieldType, Hash> &next_path,
                             const blueprint_linear_combination<FieldType> &update_successful) :
                             component<FieldType>(bp),
-                            digest_size(Hash::digest_bits), tree_depth(tree_depth), address_bits(address_bits),
+                            digest_size(Hash::get_digest_len()), tree_depth(tree_depth), address_bits(address_bits),
                             prev_leaf_digest(prev_leaf_digest), prev_root_digest(prev_root_digest), prev_path(prev_path),
                             next_leaf_digest(next_leaf_digest), next_root_digest(next_root_digest), next_path(next_path),
                             update_successful(update_successful) {
@@ -206,7 +206,7 @@ namespace nil {
                         }
 
                         static std::size_t root_size_in_bits() {
-                            return Hash::digest_bits;
+                            return Hash::get_digest_len();
                         }
                         /* for debugging purposes */
                         static std::size_t expected_constraints(const std::size_t tree_depth) {
@@ -214,12 +214,12 @@ namespace nil {
                             const std::size_t prev_hasher_constraints = tree_depth * Hash::expected_constraints(false);
                             const std::size_t next_hasher_constraints = tree_depth * Hash::expected_constraints(true);
                             const std::size_t prev_authentication_path_constraints =
-                                2 * tree_depth * Hash::digest_bits;
-                            const std::size_t prev_propagator_constraints = tree_depth * Hash::digest_bits;
-                            const std::size_t next_propagator_constraints = tree_depth * Hash::digest_bits;
+                                2 * tree_depth * Hash::get_digest_len();
+                            const std::size_t prev_propagator_constraints = tree_depth * Hash::get_digest_len();
+                            const std::size_t next_propagator_constraints = tree_depth * Hash::get_digest_len();
                             const std::size_t check_next_root_constraints =
-                                3 * (Hash::digest_bits + (FieldType::capacity()) - 1) / FieldType::capacity();
-                            const std::size_t aux_equality_constraints = tree_depth * Hash::digest_bits;
+                                3 * (Hash::get_digest_len() + (FieldType::capacity()) - 1) / FieldType::capacity();
+                            const std::size_t aux_equality_constraints = tree_depth * Hash::get_digest_len();
 
                             return (prev_hasher_constraints + next_hasher_constraints +
                                     prev_authentication_path_constraints + prev_propagator_constraints +

--- a/include/nil/crypto3/zk/snark/components/set_commitment/set_commitment_component.hpp
+++ b/include/nil/crypto3/zk/snark/components/set_commitment/set_commitment_component.hpp
@@ -71,7 +71,7 @@ namespace nil {
                             if (tree_depth == 0) {
                                 hash_element.reset(new Hash(bp, element_bits.size(), *element_block, root_digest));
                             } else {
-                                element_digest.reset(new digest_variable<FieldType>(bp, Hash::digest_bits));
+                                element_digest.reset(new digest_variable<FieldType>(bp, Hash::get_digest_len()));
                                 hash_element.reset(new Hash(bp, element_bits.size(), *element_block, *element_digest));
                                 check_membership.reset(
                                     new merkle_tree_check_read_component<FieldType, Hash>(bp,

--- a/include/nil/crypto3/zk/snark/merkle_tree.hpp
+++ b/include/nil/crypto3/zk/snark/merkle_tree.hpp
@@ -36,13 +36,13 @@ namespace nil {
         namespace zk {
             namespace snark {
                 template<typename Hash>
-                typename Hash::digest_type two_to_one_CRH(const typename Hash::digest_type &l,
-                                                          const typename Hash::digest_type &r) {
-                    typename Hash::digest_type new_input;
+                typename Hash::hash_value_type two_to_one_CRH(const typename Hash::hash_value_type &l,
+                                                          const typename Hash::hash_value_type &r) {
+                    typename Hash::hash_value_type new_input;
                     new_input.insert(new_input.end(), l.begin(), l.end());
                     new_input.insert(new_input.end(), r.begin(), r.end());
 
-                    const std::size_t digest_size = Hash::digest_bits;
+                    const std::size_t digest_size = Hash::get_digest_len();
                     assert(l.size() == digest_size);
                     assert(r.size() == digest_size);
 
@@ -68,7 +68,7 @@ namespace nil {
                 template<typename Hash, std::size_t BaseArity = 0, std::size_t SubTreeArity = 0,
                          std::size_t TopTreeArity = 0>
                 struct merkle_tree {
-                    typedef typename Hash::digest_type digest_type;
+                    typedef typename Hash::hash_value_type digest_type;
                     typedef typename Hash::merkle_authentication_path_type merkle_authentication_path_type;
 
                     constexpr static const std::size_t base_arity = BaseArity;
@@ -87,7 +87,7 @@ namespace nil {
                         depth(depth), value_size(value_size) {
                         assert(depth < sizeof(std::size_t) * 8);
 
-                        digest_size = Hash::digest_bits;
+                        digest_size = Hash::get_digest_len();
                         assert(value_size <= digest_size);
 
                         digest_type last;


### PR DESCRIPTION
@nkaskov 
Fixes some typos such as Hash::digest_bits instead of Hash::get_digest_len()