### PR TITLE
fix block_variable.block_size when using parts constructor

### DIFF
--- a/include/nil/crypto3/zk/snark/components/hashes/hash_io.hpp
+++ b/include/nil/crypto3/zk/snark/components/hashes/hash_io.hpp
@@ -99,6 +99,7 @@ namespace nil {
                             for (auto &part : parts) {
                                 bits.insert(bits.end(), part.begin(), part.end());
                             }
+                            block_size = bits.size();
                         }
 
                         block_variable(blueprint<FieldType> &bp,


### PR DESCRIPTION
Currenly when creating block variable like that:
``` c++
block_variable<field_type> block(bp, {part1, part2});
```
block.block_size would be zero.
This pr fixes that.