### PR TITLE
compatiblity with zk

### DIFF
--- a/example/test_component.hpp
+++ b/example/test_component.hpp
@@ -31,7 +31,7 @@
 #include <nil/crypto3/zk/components/blueprint.hpp>
 #include <nil/crypto3/zk/components/blueprint_variable.hpp>
 
-#include <nil/crypto3/zk/snark/relations/constraint_satisfaction_problems/r1cs.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/constraint_satisfaction_problems/r1cs.hpp>
 
 using namespace nil::crypto3::zk;
 using namespace nil::crypto3::algebra;

--- a/include/nil/crypto3/zk/components/blueprint.hpp
+++ b/include/nil/crypto3/zk/components/blueprint.hpp
@@ -34,7 +34,7 @@
 
 #include <nil/crypto3/zk/components/blueprint_variable.hpp>
 #include <nil/crypto3/zk/components/blueprint_linear_combination.hpp>
-#include <nil/crypto3/zk/snark/relations/constraint_satisfaction_problems/r1cs.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/constraint_satisfaction_problems/r1cs.hpp>
 
 namespace nil {
     namespace crypto3 {

--- a/include/nil/crypto3/zk/components/blueprint_linear_combination.hpp
+++ b/include/nil/crypto3/zk/components/blueprint_linear_combination.hpp
@@ -31,7 +31,7 @@
 #include <nil/crypto3/multiprecision/integer.hpp>
 #include <nil/crypto3/multiprecision/number.hpp>
 
-#include <nil/crypto3/zk/snark/relations/variable.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/variable.hpp>
 
 namespace nil {
     namespace crypto3 {

--- a/include/nil/crypto3/zk/components/blueprint_variable.hpp
+++ b/include/nil/crypto3/zk/components/blueprint_variable.hpp
@@ -36,7 +36,7 @@
 #include <nil/crypto3/multiprecision/integer.hpp>
 #include <nil/crypto3/multiprecision/number.hpp>
 
-#include <nil/crypto3/zk/snark/relations/variable.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/variable.hpp>
 
 namespace nil {
     namespace crypto3 {

--- a/include/nil/crypto3/zk/components/comparison.hpp
+++ b/include/nil/crypto3/zk/components/comparison.hpp
@@ -34,7 +34,7 @@
 #include <nil/crypto3/zk/components/disjunction.hpp>
 
 #include <nil/crypto3/multiprecision/number.hpp>
-#include <nil/crypto3/zk/snark/relations/constraint_satisfaction_problems/r1cs.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/constraint_satisfaction_problems/r1cs.hpp>
 
 namespace nil {
     namespace crypto3 {

--- a/include/nil/crypto3/zk/components/conjunction.hpp
+++ b/include/nil/crypto3/zk/components/conjunction.hpp
@@ -32,7 +32,7 @@
 #include <nil/crypto3/zk/components/component.hpp>
 
 #include <nil/crypto3/multiprecision/number.hpp>
-#include <nil/crypto3/zk/snark/relations/constraint_satisfaction_problems/r1cs.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/constraint_satisfaction_problems/r1cs.hpp>
 
 namespace nil {
     namespace crypto3 {

--- a/include/nil/crypto3/zk/components/disjunction.hpp
+++ b/include/nil/crypto3/zk/components/disjunction.hpp
@@ -32,7 +32,7 @@
 #include <nil/crypto3/zk/components/component.hpp>
 
 #include <nil/crypto3/multiprecision/number.hpp>
-#include <nil/crypto3/zk/snark/relations/constraint_satisfaction_problems/r1cs.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/constraint_satisfaction_problems/r1cs.hpp>
 
 namespace nil {
     namespace crypto3 {

--- a/include/nil/crypto3/zk/components/inner_product.hpp
+++ b/include/nil/crypto3/zk/components/inner_product.hpp
@@ -32,7 +32,7 @@
 #include <nil/crypto3/zk/components/component.hpp>
 
 #include <nil/crypto3/multiprecision/number.hpp>
-#include <nil/crypto3/zk/snark/relations/constraint_satisfaction_problems/r1cs.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/constraint_satisfaction_problems/r1cs.hpp>
 
 namespace nil {
     namespace crypto3 {

--- a/include/nil/crypto3/zk/components/loose_multiplexing.hpp
+++ b/include/nil/crypto3/zk/components/loose_multiplexing.hpp
@@ -34,7 +34,7 @@
 #include <nil/crypto3/zk/components/inner_product.hpp>
 
 #include <nil/crypto3/multiprecision/number.hpp>
-#include <nil/crypto3/zk/snark/relations/constraint_satisfaction_problems/r1cs.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/constraint_satisfaction_problems/r1cs.hpp>
 
 namespace nil {
     namespace crypto3 {

--- a/include/nil/crypto3/zk/components/packing.hpp
+++ b/include/nil/crypto3/zk/components/packing.hpp
@@ -32,7 +32,7 @@
 #include <nil/crypto3/zk/components/component.hpp>
 
 #include <nil/crypto3/multiprecision/number.hpp>
-#include <nil/crypto3/zk/snark/relations/constraint_satisfaction_problems/r1cs.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/constraint_satisfaction_problems/r1cs.hpp>
 
 namespace nil {
     namespace crypto3 {

--- a/test/r1cs_examples.hpp
+++ b/test/r1cs_examples.hpp
@@ -29,7 +29,7 @@
 #ifndef CRYPTO3_ZK_BLUEPRINT_R1CS_EXAMPLES_TEST_HPP
 #define CRYPTO3_ZK_BLUEPRINT_R1CS_EXAMPLES_TEST_HPP
 
-#include <nil/crypto3/zk/snark/relations/constraint_satisfaction_problems/r1cs.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/constraint_satisfaction_problems/r1cs.hpp>
 
 #include <nil/crypto3/algebra/random_element.hpp>
 


### PR DESCRIPTION
Please redirect this PR to a new branch diverging from this commit https://github.com/NilFoundation/crypto3-blueprint/tree/fc053b0a5f35c6878257caaa29495e375ba1675e
Fixing the latest blueprint is too much work so this is a temporary solution

Requires: NilFoundation/crypto3-zk#64